### PR TITLE
Integer is a long in modern versions of iOS, the compiler produces a war...

### DIFF
--- a/ZeroPush-iOS/ZeroPush.m
+++ b/ZeroPush-iOS/ZeroPush.m
@@ -160,7 +160,7 @@ static NSString *const ZeroPushAPIURLHost = @"https://api.zeropush.com";
     NSMutableDictionary *params = [NSMutableDictionary dictionary];
     [params setObject:self.deviceToken forKey:@"device_token"];
     [params setObject:self.apiKey forKey:@"auth_token"];
-    [params setObject:[NSString stringWithFormat:@"%d", badge] forKey:@"badge"];
+    [params setObject:[NSString stringWithFormat:@"%ld", (long)badge] forKey:@"badge"];
 
     NSString *url = [NSString stringWithFormat:@"%@/set_badge", ZeroPushAPIURLHost];
 


### PR DESCRIPTION
...ning when treating it as an int.

Casting it as a long both allows correct compiliation across platforms.

http://stackoverflow.com/questions/16075559/why-does-an-nsinteger-variable-have-to-typecasted-to-type-long
