### PR TITLE
Flag off compiler warnings for deprecated calls to old remote notification calls

### DIFF
--- a/ZeroPush-iOS/ZeroPush.m
+++ b/ZeroPush-iOS/ZeroPush.m
@@ -71,7 +71,10 @@ static NSString *const ZeroPushClientVersion = @"ZeroPush-iOS/2.1.0";
 
 - (void)registerForRemoteNotificationTypes:(UIRemoteNotificationType)types;
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [[UIApplication sharedApplication] registerForRemoteNotificationTypes:types];
+#pragma clang diagnostic pop
 }
 
 - (void)registerForRemoteNotifications
@@ -82,7 +85,10 @@ static NSString *const ZeroPushClientVersion = @"ZeroPush-iOS/2.1.0";
         [[UIApplication sharedApplication] registerUserNotificationSettings:notificationSettings];
         [[UIApplication sharedApplication] registerForRemoteNotifications];
     } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         [[UIApplication sharedApplication] registerForRemoteNotificationTypes: (UIRemoteNotificationTypeBadge | UIRemoteNotificationTypeSound | UIRemoteNotificationTypeAlert)];
+#pragma clang diagnostic pop
     }
 #else
     [[UIApplication sharedApplication] registerForRemoteNotificationTypes: (UIRemoteNotificationTypeBadge | UIRemoteNotificationTypeSound | UIRemoteNotificationTypeAlert)];


### PR DESCRIPTION
On second glance, this is basically a better fix for https://github.com/ZeroPush/ZeroPush-iOS/pull/7.