### PR TITLE
fix deviceTokenFromData: method

### DIFF
--- a/ZeroPush-iOS Tests/ZeroPushSpec.m
+++ b/ZeroPush-iOS Tests/ZeroPushSpec.m
@@ -109,6 +109,22 @@ describe(@"ZeroPush", ^{
     });
 
     context(@"engageWithAPIKey", ^{
+        it(@"returns a string representation of device token data", ^{
+            [[[ZeroPush deviceTokenFromData:deviceToken] should] equal: @"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"];
+        });
+        it(@"returns nil if the device token data is nil", ^{
+            [[[ZeroPush deviceTokenFromData:nil] should] beNil];
+        });
+        it(@"returns nil if the device token data is longer than 1024 bytes", ^{
+            NSMutableData *data = [NSMutableData dataWithData:deviceToken];
+            for(int i = 0; i < 35; i++){
+                [data appendData:deviceToken];
+            }
+            [[[ZeroPush deviceTokenFromData:data] should] beNil];
+        });
+    });
+
+    context(@"engageWithAPIKey", ^{
         it(@"should initialize the shared instance", ^{
             [ZeroPush engageWithAPIKey:@"testing"];
             [[[ZeroPush shared].apiKey should] equal:@"testing"];

--- a/ZeroPush-iOS/ZeroPush.m
+++ b/ZeroPush-iOS/ZeroPush.m
@@ -53,11 +53,23 @@ static NSString *const ZeroPushClientVersion = @"ZeroPush-iOS/2.1.0";
 
 + (NSString *)deviceTokenFromData:(NSData *)tokenData
 {
-    NSString *token = [tokenData description];
-    token = [token stringByReplacingOccurrencesOfString:@"<" withString:@""];
-    token = [token stringByReplacingOccurrencesOfString:@">" withString:@""];
-    token = [token stringByReplacingOccurrencesOfString:@" " withString:@""];
-    return token;
+    if (tokenData == nil) {
+        return nil;
+    }
+
+    // our token should not be very big. This is a reasonable upper limit.
+    if (tokenData.length >= 1024) {
+        return nil;
+    }
+
+    NSMutableString *deviceToken = [NSMutableString stringWithCapacity:([tokenData length] * 2)];
+    const unsigned char *bytes = (const unsigned char *)[tokenData bytes];
+
+    for (NSUInteger i = 0; i < [tokenData length]; i++) {
+        [deviceToken appendFormat:@"%02x", bytes[i]];
+    }
+
+    return [NSString stringWithString:deviceToken];
 }
 
 -(id)init {


### PR DESCRIPTION
provide a cleaner implementation that converts the bytes to hex representation rather than relying on the description method

fixes https://github.com/ZeroPush/ZeroPush-iOS/pull/17