### PR TITLE
point at pushwoosh due to zeropush shutdown

### DIFF
--- a/ZeroPush-iOS/ZeroPush.m
+++ b/ZeroPush-iOS/ZeroPush.m
@@ -8,7 +8,7 @@
 
 #import "ZeroPush.h"
 
-static NSString *const ZeroPushAPIURLHost = @"https://api.zeropush.com";
+static NSString *const ZeroPushAPIURLHost = @"https://zeropush.pushwoosh.com";
 static NSString *const ZeroPushClientVersion = @"ZeroPush-iOS/2.1.2";
 
 @interface ZeroPush ()


### PR DESCRIPTION
Is it possible to have a tracking pushwoosh branch for clients who had migrated to PushWoosh?
